### PR TITLE
Use robot-parser from simplecrawler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "node"
   - "5.1"
   - "5.0"
   - "4.2"

--- a/lib/SitemapGenerator.js
+++ b/lib/SitemapGenerator.js
@@ -7,8 +7,6 @@ var builder = require('xmlbuilder');
 var chalk = require('chalk');
 var path = require('path');
 var URL = require('url-parse');
-var robotsParser = require('robots-parser');
-var request = require('request');
 
 /**
  * Generator object, handling the crawler and file generation.
@@ -46,6 +44,7 @@ function SitemapGenerator(options) {
 
   this.crawler.initialProtocol = this.uri.protocol.replace(':', '');
   this.crawler.userAgent = 'Node/Sitemap-Generator';
+  this.crawler.respectRobotsTxt = true;
 
   if (!this.options.query) {
     this.crawler.stripQuerystring = true;
@@ -117,12 +116,7 @@ SitemapGenerator.prototype.start = function () {
     }.bind(this));
   }.bind(this));
 
-  request(this.uri.set('pathname', '/robots.txt').toString(), function (error, response, body) {
-    if (!error && response.statusCode === 200) {
-      this.robots = robotsParser(response.request.uri.href, body);
-    }
-    this.crawler.start();
-  }.bind(this));
+  this.crawler.start();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "commander": "^2.9.0",
     "chalk": "^1.1.1",
     "url-parse": "^1.0.5",
-    "robots-parser": "^1.0.0",
     "request": "^2.69.0"
   },
   "preferGlobal": true,


### PR DESCRIPTION
simplecrawler itself can use robots-parser. It can be activated with the option ```respectRobotsTxt = true```. Simplecrawler then automatically checks if the URL is allowed to be requested or not.

This small change helps to keep the code at it's core function, building the sitemap.