### PR TITLE
Simplecrawler for subpages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "node"
   - "5.1"
   - "5.0"
   - "4.2"

--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,7 @@ var generator;
 
 program.version(pkg.version)
   .usage('[options] <url>')
+  .option('-b, --baseurl', 'only allow URLs which match given <url>')
   .option('-q, --query', 'consider query string')
   .option('-f, --filename [filename]', 'sets output filename')
   .option('-p, --path [path]', 'specifies output path')
@@ -23,6 +24,7 @@ if (!program.args[0]) {
 
 generator = new SitemapGenerator({
   url: program.args[0],
+  baseurl: program.baseurl,
   query: program.query,
   path: program.path,
   filename: program.filename,

--- a/lib/SitemapGenerator.js
+++ b/lib/SitemapGenerator.js
@@ -17,9 +17,10 @@ function SitemapGenerator(options) {
   var port = 80;
   var exclude = ['gif', 'jpg', 'jpeg', 'png', 'ico', 'bmp', 'ogg', 'webp',
     'mp4', 'webm', 'mp3', 'ttf', 'woff', 'json', 'rss', 'atom', 'gz', 'zip',
-    'rar', '7z', 'css', 'js', 'gzip', 'exe'];
+    'rar', '7z', 'css', 'js', 'gzip', 'exe', 'svg'];
   var exts = exclude.join('|');
   var regex = new RegExp('\.(' + exts + ')', 'i');
+  var baseUrlRegex = new RegExp('^' + options.url + '.*');
 
   this.options = options;
   this.chunk = [];
@@ -27,7 +28,9 @@ function SitemapGenerator(options) {
   this.uri = new URL(this.options.url);
   this.crawler = new Crawler(this.uri.host);
 
-  this.crawler.initialPath = '/';
+  if (this.uri.pathname) {
+    this.crawler.initialPath = this.uri.pathname;
+  }
 
   // only crawl regular links
   this.crawler.parseScriptTags = false;
@@ -53,6 +56,13 @@ function SitemapGenerator(options) {
   this.crawler.addFetchCondition(function (parsedURL) {
     return !parsedURL.path.match(regex);
   });
+
+  if (this.options.baseurl) {
+    this.crawler.addFetchCondition(function (parsedURL) {
+      var currentUrl = parsedURL.protocol + '://' + parsedURL.host + parsedURL.uriPath;
+      return currentUrl.match(baseUrlRegex);
+    });
+  }
 }
 
 /**

--- a/lib/SitemapGenerator.js
+++ b/lib/SitemapGenerator.js
@@ -7,8 +7,6 @@ var builder = require('xmlbuilder');
 var chalk = require('chalk');
 var path = require('path');
 var URL = require('url-parse');
-var robotsParser = require('robots-parser');
-var request = require('request');
 
 /**
  * Generator object, handling the crawler and file generation.
@@ -46,6 +44,7 @@ function SitemapGenerator(options) {
 
   this.crawler.initialProtocol = this.uri.protocol.replace(':', '');
   this.crawler.userAgent = 'Node/Sitemap-Generator';
+  this.crawler.respectRobotsTxt = true;
 
   if (!this.options.query) {
     this.crawler.stripQuerystring = true;
@@ -117,12 +116,7 @@ SitemapGenerator.prototype.start = function () {
     }.bind(this));
   }.bind(this));
 
-  request(this.uri.set('pathname', '/robots.txt').toString(), function (error, response, body) {
-    if (!error && response.statusCode === 200) {
-      this.robots = robotsParser(response.request.uri.href, body);
-    }
-    this.crawler.start();
-  }.bind(this));
+  this.crawler.start();
 };
 
 /**

--- a/lib/SitemapGenerator.js
+++ b/lib/SitemapGenerator.js
@@ -7,6 +7,8 @@ var builder = require('xmlbuilder');
 var chalk = require('chalk');
 var path = require('path');
 var URL = require('url-parse');
+var robotsParser = require('robots-parser');
+var request = require('request');
 
 /**
  * Generator object, handling the crawler and file generation.
@@ -47,7 +49,6 @@ function SitemapGenerator(options) {
 
   this.crawler.initialProtocol = this.uri.protocol.replace(':', '');
   this.crawler.userAgent = 'Node/Sitemap-Generator';
-  this.crawler.respectRobotsTxt = true;
 
   if (!this.options.query) {
     this.crawler.stripQuerystring = true;
@@ -126,7 +127,12 @@ SitemapGenerator.prototype.start = function () {
     }.bind(this));
   }.bind(this));
 
-  this.crawler.start();
+  request(this.uri.set('pathname', '/robots.txt').toString(), function (error, response, body) {
+    if (!error && response.statusCode === 200) {
+      this.robots = robotsParser(response.request.uri.href, body);
+    }
+    this.crawler.start();
+  }.bind(this));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "commander": "^2.9.0",
     "chalk": "^1.1.1",
     "url-parse": "^1.0.5",
+    "robots-parser": "^1.0.0",
     "request": "^2.69.0"
   },
   "preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "commander": "^2.9.0",
     "chalk": "^1.1.1",
     "url-parse": "^1.0.5",
-    "robots-parser": "^1.0.0",
     "request": "^2.69.0"
   },
   "preferGlobal": true,

--- a/test/cli.js
+++ b/test/cli.js
@@ -190,3 +190,24 @@ describe('$ sitemap-generator --path=./tmp 127.0.0.1', function () {
     });
   });
 });
+
+describe('$ sitemap-generator --baseurl http://127.0.0.1/site', function () {
+  after(function () {
+    fs.unlink('./sitemap.xml');
+  });
+
+  before(function (done) {
+    exec('node ./cli.js --baseurl http://127.0.0.1/site', function cmd() {
+      done();
+    });
+  });
+
+  it('should include links with query parameters', function (done) {
+    fs.readFile('./sitemap.xml', function (err, data) {
+      data.toString().should.contain('/site');
+      data.toString().should.contain('/site/2');
+      data.toString().should.not.contain('/ignore');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
In this pull request a new option will be added: ```---baseurl```or ```-b```.

When you enable this option, an additional fetch condition will be added which always checks if the parsedUrl from simplecrawler matches the given <url>. This gives the user he opportunity, to create a sitemap.xml for subpages, like all URLs beginning with http://www.example.com/foo